### PR TITLE
Compatibility with legacy freenas boot pool

### DIFF
--- a/custom_components/truenas/truenas_controller.py
+++ b/custom_components/truenas/truenas_controller.py
@@ -481,7 +481,7 @@ class TrueNASControllerData(object):
             if vals["path"] in tmp_dataset:
                 self.data["pool"][uid]["available_gib"] = tmp_dataset[vals["path"]]
 
-            if vals["name"] == "boot-pool":
+            if vals["name"] in ["boot-pool", "freenas-boot"]:
                 self.data["pool"][uid]["available_gib"] = b2gib(
                     vals["root_dataset_available"]
                 )


### PR DESCRIPTION
## Proposed change
<!--

-->
  Fixes #37.  
  Old(er) installs while the name was still FreeNAS had their boot-pool created as freenas-boot.  This change will recognize these pools as well.

## Type of change
<!--
  What type of change does your PR introduces?
-->
- [X] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
<!--
  Add any other context about your PR here.
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->
- [X] The code change is tested and works locally.
- [X] The code has been formatted using Black.
- [ ] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
