### PR TITLE
Update truenas_controller.py

### DIFF
--- a/custom_components/truenas/truenas_controller.py
+++ b/custom_components/truenas/truenas_controller.py
@@ -401,8 +401,8 @@ class TrueNASControllerData(object):
                 self._systemstats_process(tmp_arr, tmp_graph[i], "cpu")
                 self.data["system_info"]["cpu_usage"] = round(
                     self.data["system_info"]["cpu_system"]
-                    + self.data["system_info"]["cpu_user"],
-                    2,
+#                    + self.data["system_info"]["cpu_user"],
+                    ,2,
                 )
 
             # Interface


### PR DESCRIPTION

## Proposed change
Hi,
I realized that CPU_usage is always abowe 50%.
![image](https://user-images.githubusercontent.com/61471407/212467554-b5815e62-e52a-4f8e-b4fb-406011844d14.png)
After I comment ling **404 #                    + self.data["system_info"]["cpu_user"],** all is showing correct now. I think Cpu_user usage is not correct to be added to main CPU_usage as according to TruNAS Dashboard my cpu usage is always between 10-40% not above 50% like home assistant integration is showing.
![image](https://user-images.githubusercontent.com/61471407/212467638-320c3492-b59d-4eec-befe-f9da873e4ba8.png)
I think User usage is not so relevant and most of users mainy look into Cpu usage which TrueNAS is showing in Dashboard.



## Type of change
<!--
  What type of change does your PR introduces?
-->
- [] Bugfix
- [ ] New feature
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
<!--
  Add any other context about your PR here.
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->
- [x] The code change is tested and works locally.
- [ ] The code has been formatted using Black.
- [ ] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
