### PR TITLE
Fix inconsistent HDD mapping

### DIFF
--- a/custom_components/truenas/coordinator.py
+++ b/custom_components/truenas/coordinator.py
@@ -772,9 +772,10 @@ class TrueNASCoordinator(DataUpdateCoordinator[None]):
 
         if temps:
             for uid, vals in self.ds["disk"].items():
-                if vals["name"] in temps: #looks for devname here
-                    self.ds["disk"][uid]["temperature"] = temps[vals["name"]] #return devname temp to uid disk
-                    #I feel like this will break in the future when TrueNAS updates to a more sensible system. Currently their own long term stats are broken by the changing devnames.
+                if vals["name"] in temps:  # looks for devname here
+                    self.ds["disk"][uid]["temperature"] = temps[vals["name"]]
+                    # return devname temp to uid disk
+                    # I feel like this will break in the future when TrueNAS updates to a more sensible system. Currently their own long term stats are broken by the changing devnames.
 
     # ---------------------------
     #   get_jail

--- a/custom_components/truenas/coordinator.py
+++ b/custom_components/truenas/coordinator.py
@@ -741,7 +741,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[None]):
         self.ds["disk"] = parse_api(
             data=self.ds["disk"],
             source=self.api.query("disk"),
-            key="devname",
+            key="identifier",
             vals=[
                 {"name": "name", "default": "unknown"},
                 {"name": "devname", "default": "unknown"},
@@ -755,6 +755,8 @@ class TrueNASCoordinator(DataUpdateCoordinator[None]):
                 {"name": "model", "default": "unknown"},
                 {"name": "rotationrate", "default": "unknown"},
                 {"name": "type", "default": "unknown"},
+                {"name": "zfs_guid", "default": "unknown"},
+                {"name": "identifier", "default": "unknown"},
             ],
             ensure_vals=[
                 {"name": "temperature", "default": 0},
@@ -769,9 +771,10 @@ class TrueNASCoordinator(DataUpdateCoordinator[None]):
         )
 
         if temps:
-            for uid in self.ds["disk"]:
-                if uid in temps:
-                    self.ds["disk"][uid]["temperature"] = temps[uid]
+            for uid, vals in self.ds["disk"].items():
+                if vals["name"] in temps: #looks for devname here
+                    self.ds["disk"][uid]["temperature"] = temps[vals["name"]] #return devname temp to uid disk
+                    #I feel like this will break in the future when TrueNAS updates to a more sensible system. Currently their own long term stats are broken by the changing devnames.
 
     # ---------------------------
     #   get_jail

--- a/custom_components/truenas/sensor_types.py
+++ b/custom_components/truenas/sensor_types.py
@@ -83,6 +83,10 @@ DEVICE_ATTRIBUTES_DISK = [
     "model",
     "rotationrate",
     "type",
+    "name",
+    "devname",
+    "zfs_guid",
+    "identifier",
 ]
 
 DEVICE_ATTRIBUTES_CPU = [
@@ -365,9 +369,9 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
         ha_group="Disks",
         data_path="disk",
         data_attribute="temperature",
-        data_name="name",
+        data_name="identifier",
         data_uid="",
-        data_reference="devname",
+        data_reference="identifier",
         data_attributes_list=DEVICE_ATTRIBUTES_DISK,
     ),
     TrueNASSensorEntityDescription(


### PR DESCRIPTION
## Proposed change
Addresses bug https://github.com/tomaae/homeassistant-truenas/issues/77
As discussed in the bug, how to name drives is a bit arbitrary but the API returns identifier that is a combination of the drives serial number and the LUN ID. As far as I know this should never be blank even for drives that wont return a serial string.

Drive entity ID will no longer be in the form sensor.devname, example: "sensor.sda".
New format is sensor.serial_lunid_SERIAL_LUNID, example: sensor.serial_lunid_WD123XYZ_5000c500c38428e

Drives can easily be renamed to more sensible things as desired by the user.
![image](https://github.com/tomaae/homeassistant-truenas/assets/1551981/b32359bb-54f9-421e-8fd8-f2ac0cb6bf7e)

![image](https://github.com/tomaae/homeassistant-truenas/assets/1551981/5d8b3152-f71d-4f92-b9e8-52d63a3e63df)

## Type of change

- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
<!--
  Add any other context about your PR here.
-->
Only tested with TrueNAS Scale. Would be great if someone could check it on Core.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->
- [x] The code change is tested and works locally.
- [x] The code has been formatted using Black.
- [ ] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
