### PR TITLE
Fix offline condition when one call fails

### DIFF
--- a/custom_components/truenas/api.py
+++ b/custom_components/truenas/api.py
@@ -67,76 +67,67 @@ class TrueNASAPI(object):
         self, service: str, method: str = "get", params: dict[str, Any] | None = {}
     ) -> Optional(list):
         """Retrieve data from TrueNAS."""
-        self.lock.acquire()
-        error = False
-        try:
-            _LOGGER.debug(
-                "TrueNAS %s query: %s, %s, %s",
-                self._host,
-                service,
-                method,
-                params,
-            )
-
-            headers = {
-                "Content-Type": "application/json",
-                "Authorization": f"Bearer {self._api_key}",
-            }
-            if method == "get":
-                response = requests_get(
-                    f"{self._url}{service}",
-                    headers=headers,
-                    params=params,
-                    verify=self._ssl_verify,
-                    timeout=10,
-                )
-
-            elif method == "post":
-                response = requests_post(
-                    f"{self._url}{service}",
-                    headers=headers,
-                    json=params,
-                    verify=self._ssl_verify,
-                    timeout=10,
-                )
-
-            if response.status_code == 200:
-                data = response.json()
-                _LOGGER.debug("TrueNAS %s query response: %s", self._host, data)
-            else:
-                error = True
-        except Exception:
-            error = True
-
-        if error:
+        error = None
+        with self.lock:
             try:
-                errorcode = response.status_code
-            except Exception:
-                errorcode = "no_response"
+                _LOGGER.debug(
+                    "TrueNAS %s query: %s, %s, %s",
+                    self._host,
+                    service,
+                    method,
+                    params,
+                )
 
-            _LOGGER.warning(
-                'TrueNAS %s unable to fetch data "%s" (%s)',
-                self._host,
-                service,
-                errorcode,
-            )
+                headers = {
+                    "Content-Type": "application/json",
+                    "Authorization": f"Bearer {self._api_key}",
+                }
+                if method == "get":
+                    response = requests_get(
+                        f"{self._url}{service}",
+                        headers=headers,
+                        params=params,
+                        verify=self._ssl_verify,
+                        timeout=10,
+                    )
 
-            if (
-                errorcode != 500
-                and service != "reporting/get_data"
-                and service != "reporting/netdata_get_data"
-            ):
+                elif method == "post":
+                    response = requests_post(
+                        f"{self._url}{service}",
+                        headers=headers,
+                        json=params,
+                        verify=self._ssl_verify,
+                        timeout=10,
+                    )
+
+                if response.status_code == 200:
+                    data = response.json()
+                    _LOGGER.debug("TrueNAS %s query response: %s", self._host, data)
+                    self._error = ""
+                else:
+                    # if we didn't get a 200, we are still connected, but there was no valid data
+                    _LOGGER.warning(
+                        'TrueNAS %s error while fetch data "%s" (%s)',
+                        self._host,
+                        service,
+                        response.status_code,
+                    )
+                    self._error = response.status_code
+                    return None
+            except Exception as exception:
+                error = str(exception)
+                _LOGGER.warning(
+                    'TrueNAS %s unable to fetch data "%s" (%s)',
+                    self._host,
+                    service,
+                    error
+                )
                 self._connected = False
+                self._error = error
+                return None
 
-            self._error = errorcode
-            self.lock.release()
-            return None
-
-        self._connected = True
-        self._error = ""
-        self.lock.release()
-
-        return data
+            self._connected = True
+            return data
 
     @property
     def error(self):

--- a/custom_components/truenas/api.py
+++ b/custom_components/truenas/api.py
@@ -120,7 +120,7 @@ class TrueNASAPI(object):
                     'TrueNAS %s unable to fetch data "%s" (%s)',
                     self._host,
                     service,
-                    error
+                    error,
                 )
                 self._connected = False
                 self._error = error

--- a/custom_components/truenas/api.py
+++ b/custom_components/truenas/api.py
@@ -123,7 +123,7 @@ class TrueNASAPI(object):
                     error,
                 )
                 self._connected = False
-                self._error = error
+                self._error = "no_response"
                 return None
 
             self._connected = True


### PR DESCRIPTION
## Proposed change
This change redoes the API request logic to not get knocked offline for a bad response code, changing it to only go offline if an API causes an exception (like timeout or a request error, etc). Resolves  #191.


## Type of change
<!--
  What type of change does your PR introduces?
-->
- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
I have been having the same issue as #191 so decided to rework the logic slightly, also fixed the lock handling to be a little cleaner.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->
- [x] The code change is tested and works locally.
- [x] The code has been formatted using Black.
- [ ] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
