### PR TITLE
Increase timeout to 30s for slower hardware

### DIFF
--- a/custom_components/truenas/api.py
+++ b/custom_components/truenas/api.py
@@ -88,7 +88,7 @@ class TrueNASAPI(object):
                     headers=headers,
                     params=params,
                     verify=self._ssl_verify,
-                    timeout=10,
+                    timeout=30,
                 )
 
             elif method == "post":
@@ -97,7 +97,7 @@ class TrueNASAPI(object):
                     headers=headers,
                     json=params,
                     verify=self._ssl_verify,
-                    timeout=10,
+                    timeout=30,
                 )
 
             if response.status_code == 200:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here. If it fixes a bug
  or resolves a feature request, be sure to link to that issue.
-->
Requests can take 12 to 16s on slow hardware like mine, and the default timeout is 10s, which I feel is too short, so I changed it to something more acceptable for everyone  (30s).

## Type of change
<!--
  What type of change does your PR introduces?
-->
- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
<!--
  Add any other context about your PR here.
-->
This mostly fix the issues with empty response like #207
## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->
- [x] The code change is tested and works locally.
- [ ] The code has been formatted using Black.
- [ ] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
