### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,4 +1,6 @@
 name: SonarCloud
+permissions:
+  contents: read
 on:
   push:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/tomaae/homeassistant-truenas/security/code-scanning/7](https://github.com/tomaae/homeassistant-truenas/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimum required permissions. Based on the workflow's functionality, it primarily checks out code and performs a SonarQube scan. These actions typically require only `contents: read` permissions. We will add this permission to the root of the workflow to apply it to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
