### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
   release_zip:
     name: Prepare release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -30,6 +32,8 @@ jobs:
   releasenotes:
     name: Prepare releasenotes
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/tomaae/homeassistant-truenas/security/code-scanning/10](https://github.com/tomaae/homeassistant-truenas/security/code-scanning/10)

To fix the issue, we will add a `permissions` block to the workflow. This block will specify the minimal permissions required for the `GITHUB_TOKEN` in each job. For the `release_zip` job, the `contents: write` permission is needed to upload the zip file to the release. For the `releasenotes` job, the `contents: read` permission is sufficient to read repository contents, and `contents: write` is required to update release notes. These permissions will be explicitly defined in the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
