### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ on:
       - 'tests/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
 
   black:
@@ -57,6 +60,8 @@ jobs:
     name: Security check - Bandit
     needs: [tests]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Check out code from GitHub
         uses: "actions/checkout@v4"
@@ -76,6 +81,8 @@ jobs:
     name: Check hassfest
     needs: [tests]
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
     steps:
       - name: Check out code from GitHub
         uses: "actions/checkout@v4"


### PR DESCRIPTION
Potential fix for [https://github.com/tomaae/homeassistant-truenas/security/code-scanning/9](https://github.com/tomaae/homeassistant-truenas/security/code-scanning/9)

To fix the issue, we will add a `permissions` block to the workflow. This block will define the minimal permissions required for each job. For example:
- The `black` job only needs `contents: read` to check out the code.
- The `tests` job requires `contents: read` to check out the code and install dependencies.
- The `security` job requires `contents: read` for code checkout and `contents: write` to upload artifacts.
- The `validate` job only needs `contents: read` to check out the code and run `hassfest`.

We will add a `permissions` block at the root level of the workflow to apply default permissions (`contents: read`) to all jobs. Then, we will override this block for specific jobs that require additional permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
