### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -1,5 +1,8 @@
 name: HACS Action
 
+permissions:
+  contents: read
+
 on:
   push:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/tomaae/homeassistant-truenas/security/code-scanning/2](https://github.com/tomaae/homeassistant-truenas/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the workflow level to restrict the permissions of the `GITHUB_TOKEN`. Based on the provided workflow, it appears that the workflow primarily checks out the repository and uses the `hacs/action` with a category input. These operations likely only require `contents: read` permissions. We will add this minimal permission to the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
