### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/conflicts.yml
+++ b/.github/workflows/conflicts.yml
@@ -2,6 +2,9 @@ on:
   push:
   pull_request:
       types: [opened, synchronize, reopened]
+permissions:
+  contents: read
+  pull-requests: write
 jobs:
   check_conflicts:
     name: Check for PR merge conflicts


### PR DESCRIPTION
Potential fix for [https://github.com/tomaae/homeassistant-truenas/security/code-scanning/3](https://github.com/tomaae/homeassistant-truenas/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow uses the `GITHUB_TOKEN` to label pull requests with conflicts, it requires `contents: read` to access repository contents and `pull-requests: write` to modify pull requests. These permissions should be explicitly defined at the workflow level to ensure the `GITHUB_TOKEN` has only the necessary access.

The `permissions` block should be added at the root level of the workflow file, applying to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
