### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,6 +8,10 @@ jobs:
   stale:
     name: Stale
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - uses: "actions/stale@v9"
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/tomaae/homeassistant-truenas/security/code-scanning/8](https://github.com/tomaae/homeassistant-truenas/security/code-scanning/8)

To fix the issue, we need to add a `permissions` block to the workflow. Since the `actions/stale` action interacts with issues and pull requests, we will grant it the minimal required permissions: `contents: read`, `issues: write`, and `pull-requests: write`. These permissions will be added at the job level to ensure they apply only to the `stale` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
