### PR TITLE
Check entity_id suffix

### DIFF
--- a/custom_components/truenas/entity.py
+++ b/custom_components/truenas/entity.py
@@ -120,10 +120,11 @@ class TrueNASEntity(CoordinatorEntity[TrueNASCoordinator], Entity):
             if dev_group in self._data:
                 dev_group = self._data[dev_group]
 
+        entity_id = f"{platform.domain}.{self._inst.lower()}_{slugify(str(dev_group).lower())}"
         if suffix := slugify(str(self.name).lower()):
-            self.entity_id = f"{platform.domain}.{self._inst.lower()}_{slugify(str(dev_group).lower())}_{suffix}"
+            self.entity_id = f"{entity_id}_{suffix}"
         else:
-            self.entity_id = f"{platform.domain}.{self._inst.lower()}_{slugify(str(dev_group).lower())}"
+            self.entity_id = entity_id
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/truenas/entity.py
+++ b/custom_components/truenas/entity.py
@@ -120,7 +120,10 @@ class TrueNASEntity(CoordinatorEntity[TrueNASCoordinator], Entity):
             if dev_group in self._data:
                 dev_group = self._data[dev_group]
 
-        self.entity_id = f"{platform.domain}.{self._inst.lower()}_{slugify(str(dev_group).lower())}_{slugify(str(self.name).lower())}"
+        if suffix := slugify(str(self.name).lower()):
+            self.entity_id = f"{platform.domain}.{self._inst.lower()}_{slugify(str(dev_group).lower())}_{suffix}"
+        else:
+            self.entity_id = f"{platform.domain}.{self._inst.lower()}_{slugify(str(dev_group).lower())}"
 
     @callback
     def _handle_coordinator_update(self) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here. If it fixes a bug
  or resolves a feature request, be sure to link to that issue.
-->
With this fix we check if the `entity_id` suffix is ​​not empty and only then we add it to `entity_id`.

Fixes https://github.com/tomaae/homeassistant-truenas/issues/315



## Type of change
<!--
  What type of change does your PR introduces?
-->
- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
<!--
  Add any other context about your PR here.
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->
- [x] The code change is tested and works locally.
- [x] The code has been formatted using Black.
- [ ] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.

## Summary by Sourcery

Bug Fixes:
- Prevent generating entity_ids with trailing underscores when the slugified entity name is empty.