### PR TITLE
Fix TrueNAS Scale 25.10 integration going offline due to 400/404 errors

### DIFF
--- a/custom_components/truenas/api.py
+++ b/custom_components/truenas/api.py
@@ -14,6 +14,9 @@ from homeassistant.core import HomeAssistant
 _LOGGER = getLogger(__name__)
 disable_warnings(InsecureRequestWarning)
 
+NO_RESPONSE_ERROR = "no_response"
+CONNECTION_FATAL_ERRORS = {401, 403, NO_RESPONSE_ERROR}
+
 
 # ---------------------------
 #   TrueNASAPI
@@ -112,7 +115,7 @@ class TrueNASAPI(object):
             try:
                 errorcode = response.status_code
             except Exception:
-                errorcode = "no_response"
+                errorcode = NO_RESPONSE_ERROR
 
             _LOGGER.warning(
                 'TrueNAS %s unable to fetch data "%s" (%s)',
@@ -121,7 +124,7 @@ class TrueNASAPI(object):
                 errorcode,
             )
 
-            if errorcode in (401, 403, "no_response"):
+            if errorcode in CONNECTION_FATAL_ERRORS:
                 self._connected = False
 
             self._error = errorcode

--- a/custom_components/truenas/api.py
+++ b/custom_components/truenas/api.py
@@ -121,11 +121,7 @@ class TrueNASAPI(object):
                 errorcode,
             )
 
-            if (
-                errorcode != 500
-                and service != "reporting/get_data"
-                and service != "reporting/netdata_get_data"
-            ):
+            if errorcode in (401, 403, "no_response"):
                 self._connected = False
 
             self._error = errorcode

--- a/custom_components/truenas/coordinator.py
+++ b/custom_components/truenas/coordinator.py
@@ -960,7 +960,7 @@ class TrueNASCoordinator(DataUpdateCoordinator[None]):
         temps = self.api.query(
             "disk/temperatures",
             method="post",
-            params={"names": []},
+            params={},
         )
 
         if temps:


### PR DESCRIPTION
## Proposed change

Fixes the integration going permanently offline (\"TrueNas Disconnected\") for users running TrueNAS Scale 25.10.

### Root cause

Two API changes in TrueNAS Scale 25.10 break the integration:

1. **`disk/temperatures` changed its POST body** — 25.10 rejects `{\"names\": []}` with a 400 error. The correct call is an empty body `{}`.
2. **Core-only endpoints return 404 on Scale** — `jail`, `chart/release`, and others don't exist on Scale and return 404.

The existing disconnect logic treated *any* unexpected HTTP error code as a fatal connection failure, setting `_connected = False` and raising `UpdateFailed(\"TrueNas Disconnected\")`. This took the entire integration offline on first poll.

### Fix

- **`api.py`**: Only mark the connection as failed on auth errors (401/403) or no response at all. Benign errors like 400 (changed API params) or 404 (Core-only endpoints absent on Scale) are logged as warnings but don't disconnect.
- **`coordinator.py`**: Fix `disk/temperatures` POST body from `{\"names\": []}` to `{}`.

## Type of change

- [x] Bugfix

## Additional information

Tested on TrueNAS Scale 25.10.1 (Electric Eel) with integration v1.3.1. Pool, dataset, disk, VM, and service sensors all populate correctly after this fix.

Fixes #316

## Summary by Sourcery

Relax connection failure handling for TrueNAS API errors and correct the disk temperature query payload for TrueNAS Scale 25.10.

Bug Fixes:
- Prevent the integration from marking the TrueNAS connection as offline on non-auth HTTP errors such as 400/404.
- Fix disk temperature polling on TrueNAS Scale 25.10 by sending an empty POST body to the disk/temperatures endpoint instead of a names list.