### PR TITLE
Use SensorDeviceClass.UPTIME for uptime sensor

### DIFF
--- a/custom_components/truenas/sensor_types.py
+++ b/custom_components/truenas/sensor_types.py
@@ -170,9 +170,8 @@ SENSOR_TYPES: tuple[TrueNASSensorEntityDescription, ...] = (
     TrueNASSensorEntityDescription(
         key="system_uptime",
         name="Uptime",
-        icon="mdi:clock-outline",
         native_unit_of_measurement=None,
-        device_class=SensorDeviceClass.TIMESTAMP,
+        device_class=SensorDeviceClass.UPTIME,
         state_class=None,
         entity_category=EntityCategory.DIAGNOSTIC,
         ha_group="System",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here. If it fixes a bug
  or resolves a feature request, be sure to link to that issue.
-->
Use new `SensorDeviceClass.UPTIME` for uptime sensor. Requires HA 2026.5.0.

## Type of change
<!--
  What type of change does your PR introduces?
-->
- [ ] Bugfix
- [ ] New feature
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
<!--
  Add any other context about your PR here.
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->
- [x] The code change is tested and works locally.
- [x] The code has been formatted using Black.
- [ ] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.

## Summary by Sourcery

Enhancements:
- Switch the TrueNAS system uptime sensor to SensorDeviceClass.UPTIME and drop the custom icon to align with the new Home Assistant uptime semantics.