### PR TITLE
fix: Don't report pending app updates for stopped apps

### DIFF
--- a/custom_components/truenas/update.py
+++ b/custom_components/truenas/update.py
@@ -122,6 +122,10 @@ class TrueNASAppUpdate(TrueNASEntity, UpdateEntity):
     @property
     def latest_version(self) -> str:
         """Latest version available for install."""
+        if not self._data["running"]:
+            # A stopped app cannot be upgraded, do not report a pending update
+            return self._data["version"]
+
         return self._data["latest_version"]
 
     async def async_install(self, version: str, backup: bool, **kwargs: Any) -> None:

--- a/custom_components/truenas/update.py
+++ b/custom_components/truenas/update.py
@@ -122,7 +122,7 @@ class TrueNASAppUpdate(TrueNASEntity, UpdateEntity):
     @property
     def latest_version(self) -> str:
         """Latest version available for install."""
-        if not self._data["running"]:
+        if not self._data.get("running", True):
             # A stopped app cannot be upgraded, do not report a pending update
             return self._data["version"]
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here. If it fixes a bug
  or resolves a feature request, be sure to link to that issue.
-->
Follow-up to #221: a stopped app cannot be upgraded, so the app update entity should not report a pending update while the app is not running.

The `TrueNASAppUpdate` entity now returns the installed version as `latest_version` while the app is stopped, so Home Assistant only shows a pending update for apps that are actually running (and therefore upgradeable). Once the app is started again, the pending update shows up as usual.

## Type of change
<!--
  What type of change does your PR introduces?
-->
- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
<!--
  Add any other context about your PR here.
-->
This complements the existing guard in `async_install`, which already refuses to upgrade a stopped app — now the update is not offered in the UI in the first place.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->
- [x] The code change is tested and works locally.
- [x] The code has been formatted using Black.
- [ ] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Ensure the TrueNAS app update entity reports the installed version as latest when the app is stopped so Home Assistant only shows updates for running apps.