### PR TITLE
Issue 264 unsupported operand type error fix

### DIFF
--- a/custom_components/truenas/coordinator.py
+++ b/custom_components/truenas/coordinator.py
@@ -843,7 +843,6 @@ class TrueNASCoordinator(DataUpdateCoordinator[None]):
         )
 
         for uid, vals in self.ds["vm"].items():
-            # self.ds["vm"][uid]["memory"] = round(vals["memory"] / 1024 / 1024 / 1024)
             memory_val = vals.get("memory")
             self.ds["vm"][uid]["memory"] = round(memory_val / 1024 / 1024 / 1024) if memory_val is not None else 0
             self.ds["vm"][uid]["running"] = vals["status"] == "RUNNING"

--- a/custom_components/truenas/coordinator.py
+++ b/custom_components/truenas/coordinator.py
@@ -843,7 +843,9 @@ class TrueNASCoordinator(DataUpdateCoordinator[None]):
         )
 
         for uid, vals in self.ds["vm"].items():
-            self.ds["vm"][uid]["memory"] = round(vals["memory"] / 1024 / 1024 / 1024)
+            # self.ds["vm"][uid]["memory"] = round(vals["memory"] / 1024 / 1024 / 1024)
+            memory_val = vals.get("memory")
+            self.ds["vm"][uid]["memory"] = round(memory_val / 1024 / 1024 / 1024) if memory_val is not None else 0
             self.ds["vm"][uid]["running"] = vals["status"] == "RUNNING"
 
     # ---------------------------


### PR DESCRIPTION
Fixed operand type error when adding new instance to ha
credit to https://github.com/tomaae/homeassistant-truenas/issues/264#issuecomment-3945506901

## Summary by Sourcery

Bug Fixes:
- Prevent crashes when VM memory value is absent by defaulting the computed memory to zero.